### PR TITLE
Resolve the shadow issue in the menu

### DIFF
--- a/src/landing/home.css
+++ b/src/landing/home.css
@@ -154,7 +154,7 @@ font-size: 24px !important;
 margin-top: 60%;
 }
 
-.css-1poimk-MuiPaper-root-MuiMenu-paper-MuiPaper-root-MuiPopover-paper{
+.MuiMenu-paper {
     box-shadow: none !important;
 }
 


### PR DESCRIPTION
ReactJS generates CSS code for each component in the production build. One should always use the generic class name to override the property as per the documentation and not the generated CSS name (displayed in the inspect element).

Tested and deployed. Can be reviewed and merged.